### PR TITLE
fix: Sustain custom values in case of validation errors

### DIFF
--- a/app/controllers/admin/help_requests_controller.rb
+++ b/app/controllers/admin/help_requests_controller.rb
@@ -50,6 +50,7 @@ module Admin
         redirect_to action: :index
       else
         fill_volunteers
+        fill_custom_values
         flash.now[:error] = "Просьба не создана #{@help_request.errors.messages.inspect}"
         render :edit
       end
@@ -95,6 +96,22 @@ module Admin
       render json: custom_fields_data
     end
     # rubocop:enable Metrics/MethodLength
+
+    def fill_custom_values
+      data = params[:help_request][:custom_values_attributes].permit!.to_h
+      @custom_values = data.map do |id, custom_value|
+        custom_field_id = custom_value[:custom_field_id]
+        custom_field = CustomField.find_by_id custom_field_id
+        next unless custom_field
+        {
+          id: nil,
+          value: custom_value[:value],
+          custom_field_id: custom_value[:custom_field_id],
+          name: custom_field.name,
+          data_type: custom_field.data_type
+        }
+      end.compact
+    end
 
     def clone
       authorize @help_request

--- a/app/javascript/custom_fields/custom_fields.js
+++ b/app/javascript/custom_fields/custom_fields.js
@@ -5,6 +5,15 @@ export default class CustomFieldsPanel {
     this.url = el.dataset.url
     
     this.selectEl.addEventListener('change', this.updateCustomValues.bind(this));
+    const currentData = el.dataset.values
+    
+    if (currentData) {
+      const parsedCurrentData = JSON.parse(currentData)
+      if (parsedCurrentData) {
+        this.renderData(parsedCurrentData);
+        return
+      }
+    }
     this.updateCustomValues();
   }
 

--- a/app/views/admin/help_requests/_custom_values.html.erb
+++ b/app/views/admin/help_requests/_custom_values.html.erb
@@ -1,6 +1,6 @@
 <p>
   <h4><%= t(".header") %></h4>
-  <div id='js-custom-fields' data-url='<%= custom_fields_admin_help_request_path(f.object.try(:id) || 0) %>'>
+  <div id='js-custom-fields' data-values='<%= @custom_values.to_json %>' data-url='<%= custom_fields_admin_help_request_path(f.object.try(:id) || 0) %>'>
     <%= f.input :help_request_kind_id, collection: help_request_kinds, include_blank: false, input_html: { class: 'js-help-request-kind-selector' } %>
     <div class='js-custom-fields-container'></div>
   </div>


### PR DESCRIPTION
Делаем serve-like рендеринг кастомных полей в случае если не удалось создать запись. Так их не прийдется заполнять с нуля. Хотя потом если менять тип просьбы мы все равно их потеряем, но это все равно улучшает user experiance

https://github.com/helphubteam/helphub-archived/issues/280