### PR TITLE
Add data to push notifications for android

### DIFF
--- a/app/services/notifications/base.rb
+++ b/app/services/notifications/base.rb
@@ -1,9 +1,10 @@
 module Notifications
   class Base
-    def initialize(title:, body:, user:)
+    def initialize(title:, body:, data:, user:)
       @title = title
       @body = body
       @user = user
+      @data = data
     end
 
     def call
@@ -12,6 +13,6 @@ module Notifications
 
     protected
 
-    attr_reader :title, :body, :user
+    attr_reader :title, :body, :user, :data
   end
 end

--- a/app/services/notifications/broadcast_push_notification.rb
+++ b/app/services/notifications/broadcast_push_notification.rb
@@ -1,9 +1,10 @@
 module Notifications
   class BroadcastPushNotification
-    def initialize(organization:, title:, body:)
+    def initialize(organization:, title:, body:, data:)
       @organization = organization
       @title = title
       @body = body
+      @data = data
     end
 
     def call
@@ -14,11 +15,11 @@ module Notifications
 
     private
 
-    attr_reader :organization, :title, :body
+    attr_reader :organization, :title, :body, :data
 
     def notify_volunteer(user_id)
       PushNotificationWorker.perform_async(
-        user_id, title, body
+        user_id, title, body, data
       )
     end
   end

--- a/app/services/notifications/platforms/android.rb
+++ b/app/services/notifications/platforms/android.rb
@@ -10,7 +10,8 @@ module Notifications
           notification: {
             title: title,
             body: body,
-            sound: 'default'
+            sound: 'default',
+            data: data
           }
         }
         fcm.send(registration_ids, options)

--- a/app/services/notifications/push_notification.rb
+++ b/app/services/notifications/push_notification.rb
@@ -12,7 +12,8 @@ module Notifications
       notification_driver.new(
         user: user,
         title: title,
-        body: body
+        body: body,
+        data: data
       ).call
     end
   end

--- a/app/services/recurring.rb
+++ b/app/services/recurring.rb
@@ -45,10 +45,13 @@ class Recurring < ApplicationService
   def notify_volunteers_on_creation(help_request)
     return unless help_request.organization.notify_if_new
 
+    data = { type: 'help_request:created', id: help_request.id.to_s }
+
     BroadcastPushNotificationWorker.perform_async(
       help_request.organization_id,
       I18n.t('notifications.help_request.create'),
-      ''
+      '',
+      data
     )
   end
 end

--- a/app/use_cases/admin/help_request_cases/base.rb
+++ b/app/use_cases/admin/help_request_cases/base.rb
@@ -99,9 +99,9 @@ module Admin
         )
       end
 
-      def notify_volunteers(message)
+      def notify_volunteers(message, data = {})
         BroadcastPushNotificationWorker.perform_async(
-          current_user.organization_id, message, ''
+          current_user.organization_id, message, '', data
         )
       end
     end

--- a/app/use_cases/admin/help_request_cases/clone.rb
+++ b/app/use_cases/admin/help_request_cases/clone.rb
@@ -23,12 +23,15 @@ module Admin
       private
 
       def notify_volunteers_on_creation
-        notify_volunteers(I18n.t('notifications.help_request.create')) if current_user.organization.notify_if_new
+        notify_volunteers(
+          I18n.t('notifications.help_request.create'),
+          { type: 'help_request:created', id: help_request.id.to_s }
+        ) if current_user.organization.notify_if_new
       end
 
-      def notify_volunteers(message)
+      def notify_volunteers(message, data)
         BroadcastPushNotificationWorker.perform_async(
-          current_user.organization_id, message, ''
+          current_user.organization_id, message, '', data
         )
       end
 

--- a/app/use_cases/admin/help_request_cases/create.rb
+++ b/app/use_cases/admin/help_request_cases/create.rb
@@ -21,7 +21,12 @@ module Admin
       private
 
       def notify_volunteers_on_creation
-        notify_volunteers(I18n.t('notifications.help_request.create')) if current_user.organization.notify_if_new
+        if current_user.organization.notify_if_new
+          notify_volunteers(
+            I18n.t('notifications.help_request.create'),
+            { type: 'help_request:created', id: help_request.id.to_s }
+          )
+        end
       end
     end
   end

--- a/app/use_cases/admin/help_request_cases/push_notifications.rb
+++ b/app/use_cases/admin/help_request_cases/push_notifications.rb
@@ -30,7 +30,7 @@ module Admin
           body: body,
           data: {
             type: 'help_request:updated',
-            id: help_request.id_to_s
+            id: help_request.id.to_s
           }
         }
       end
@@ -43,7 +43,7 @@ module Admin
           body: body,
           data: {
             type: 'help_request:assigned',
-            id: help_request.id_to_s
+            id: help_request.id.to_s
           }
         }
       end
@@ -56,7 +56,7 @@ module Admin
           body: body,
           data: {
             type: 'help_request:unassigned',
-            id: help_request.id_to_s
+            id: help_request.id.to_s
           }
         }
       end

--- a/app/use_cases/admin/help_request_cases/push_notifications.rb
+++ b/app/use_cases/admin/help_request_cases/push_notifications.rb
@@ -17,7 +17,8 @@ module Admin
         Notifications::PushNotification.new(
           user: user,
           title: message_data[:title],
-          body: message_data[:body]
+          body: message_data[:body],
+          data: message_data[:data] || {}
         ).call
       end
 
@@ -26,7 +27,11 @@ module Admin
         body += " (#{help_request.title})" if help_request.title.present?
         {
           title: user_full_name(moderator),
-          body: body
+          body: body,
+          data: {
+            type: 'help_request:updated',
+            id: help_request.id_to_s
+          }
         }
       end
 
@@ -35,7 +40,11 @@ module Admin
         body += " (#{help_request.title})" if help_request.title.present?
         {
           title: user_full_name(moderator),
-          body: body
+          body: body,
+          data: {
+            type: 'help_request:assigned',
+            id: help_request.id_to_s
+          }
         }
       end
 
@@ -44,7 +53,11 @@ module Admin
         body += " (#{help_request.title})" if help_request.title.present?
         {
           title: user_full_name(moderator),
-          body: body
+          body: body,
+          data: {
+            type: 'help_request:unassigned',
+            id: help_request.id_to_s
+          }
         }
       end
 

--- a/app/workers/broadcast_push_notification_worker.rb
+++ b/app/workers/broadcast_push_notification_worker.rb
@@ -4,12 +4,13 @@ class BroadcastPushNotificationWorker
   # TODO: We will use worker for push notifications later on
   # as our heroku staging doesn't support this
   def perform(*args)
-    organization_id, title, body = args
+    organization_id, title, body, data = args
     organization = Organization.find(organization_id)
     Notifications::BroadcastPushNotification.new(
       organization: organization,
       body: body,
-      title: title
+      title: title,
+      data: data
     ).call
   end
 end

--- a/app/workers/push_notification_worker.rb
+++ b/app/workers/push_notification_worker.rb
@@ -4,12 +4,13 @@ class PushNotificationWorker
   # TODO: We will use worker for push notifications later on
   # as our heroku staging doesn't support this
   def perform(*args)
-    user_id, title, body = args
+    user_id, title, body, data = args
     user = User.find(user_id)
     Notifications::PushNotification.new(
       user: user,
       body: body,
-      title: title
+      title: title,
+      data: data
     ).call
   end
 end


### PR DESCRIPTION
Передаем дату с ID просьбы и типом нотификации для того чтобы открывать конкретную просьбу в приложении по нажатию. Реализовано только для андроид пока что потому что думаем сделать нотификации универсальными